### PR TITLE
Flock-only mode, expanded signatures, and GitHub Actions CI

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,115 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:   # allow manual test builds without tagging
+
+permissions:
+  contents: write      # needed to create GitHub Releases
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Arduino CLI ────────────────────────────────────────────────────────
+      - name: Install arduino-cli
+        uses: arduino/setup-arduino-cli@v2
+
+      - name: Configure board manager and enable unsafe lib install
+        run: |
+          arduino-cli config init
+          arduino-cli config set board_manager.additional_urls \
+            https://espressif.github.io/arduino-esp32/package_esp32_index.json
+          arduino-cli config set library.enable_unsafe_install true
+
+      - name: Install ESP32 Arduino core
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install esp32:esp32
+
+      # ── Libraries ─────────────────────────────────────────────────────────
+      - name: Install libraries from Library Manager
+        run: |
+          arduino-cli lib install "TinyGPSPlus"
+          arduino-cli lib install "Adafruit GFX Library"
+          arduino-cli lib install "Adafruit SSD1306"
+          arduino-cli lib install "Adafruit NeoPixel"
+          arduino-cli lib install "ESP32Time"
+
+      # ESPAsyncWebServer and its AsyncTCP dependency are not in the
+      # official Library Manager; install directly from GitHub.
+      - name: Install AsyncTCP and ESPAsyncWebServer from GitHub
+        run: |
+          arduino-cli lib install \
+            --git-url https://github.com/me-no-dev/AsyncTCP.git
+          arduino-cli lib install \
+            --git-url https://github.com/me-no-dev/ESPAsyncWebServer.git
+
+      # ── Secrets stub ──────────────────────────────────────────────────────
+      # secrets.h is gitignored (contains WiFi credentials for file-sharing
+      # mode). A placeholder is sufficient for compilation; no actual
+      # credentials are needed or embedded in CI builds.
+      - name: Create placeholder secrets.h
+        run: |
+          cat > SignalScout/secrets.h << 'EOF'
+          #ifndef SECRETS_H
+          #define SECRETS_H
+          const char* WIFI_SSID     = "";
+          const char* WIFI_PASSWORD = "";
+          #endif
+          EOF
+
+      # ── Compile ───────────────────────────────────────────────────────────
+      # Board: ESP32-C5 (16 MB flash, 8 MB PSRAM).
+      # Adjust FlashSize / PSRAM options if your hardware differs.
+      - name: Compile sketch
+        run: |
+          arduino-cli compile \
+            --fqbn "esp32:esp32:esp32c5:FlashSize=16M,PartitionScheme=default,PSRAM=enabled" \
+            --export-binaries \
+            --output-dir build \
+            SignalScout
+
+      - name: List build output
+        run: ls -lh build/
+
+      # ── Merge into a single flashable binary ──────────────────────────────
+      # Produces SignalScout-merged.bin that can be flashed at address 0x0
+      # with esptool.py or the Espressif Flash Download Tool.
+      - name: Merge bootloader + partition table + app into one binary
+        run: |
+          pip install esptool --quiet
+          esptool.py --chip esp32c5 merge_bin \
+            --output build/SignalScout-merged.bin \
+            0x0     build/SignalScout.ino.bootloader.bin \
+            0x8000  build/SignalScout.ino.partitions.bin \
+            0x10000 build/SignalScout.ino.bin
+
+      # ── Artifacts (every run) ─────────────────────────────────────────────
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SignalScout-firmware-${{ github.ref_name || github.sha }}
+          path: |
+            build/SignalScout.ino.bin
+            build/SignalScout.ino.bootloader.bin
+            build/SignalScout.ino.partitions.bin
+            build/SignalScout-merged.bin
+
+      # ── GitHub Release (tag pushes only) ──────────────────────────────────
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "SignalScout ${{ github.ref_name }}"
+          generate_release_notes: true
+          files: |
+            build/SignalScout-merged.bin
+            build/SignalScout.ino.bin
+            build/SignalScout.ino.bootloader.bin
+            build/SignalScout.ino.partitions.bin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Logs all scan results to SD card via SPI
 - Outputs scan data to serial monitor for debugging
 - Hold mode button 1s to pause scanning (flushes SD card, opens settings menu)
-- In settings menu: short tap advances cursor, hold 1s activates selected item (toggle WiFi/BLE or resume)
+- In settings menu: short tap advances cursor, hold 1s activates selected item (toggle WiFi/BLE/Flock-only or resume)
 
 **File Sharing Mode (Hold button at boot):**
 - Hold the mode button while powering on — a 2-second window at boot selects this mode
@@ -40,9 +40,12 @@ This is an Arduino sketch (.ino file) that should be developed using:
 - Arduino CLI, or
 - PlatformIO
 
+**CI/CD:** GitHub Actions (`.github/workflows/build-release.yml`) compiles the sketch on every `v*` tag push using arduino-cli + the ESP32 core, then creates a GitHub Release with the compiled binaries attached. Push a tag (`git tag vX.Y.Z && git push origin vX.Y.Z`) to trigger a release. `workflow_dispatch` allows manual test builds without tagging. The workflow creates a stub `secrets.h` at compile time (empty credentials) — the gitignored real file is never committed or embedded in releases.
+
 ## File Structure
 
 - `SignalScout.ino` - Main Arduino sketch with WiFi/BLE scanning and SD card logging
+- `.github/workflows/build-release.yml` - GitHub Actions CI: compiles on tag push, creates GitHub Release with merged binary attached
 
 ## Architecture
 
@@ -105,7 +108,11 @@ The sketch is structured around four main components:
    - **Center Left**: Device counts - WiFi "W:X(XX)", BLE "B:X(XX)"
      - Asterisk (*) appears after count when actively scanning (e.g., "W:5(23)*")
      - Shows last scan count and total unique devices seen
-   - **Flock Alert Row**: `FLOCK:N` shown inverted (black-on-white) when Flock devices have been seen
+     - `W:--` / `B:--` shown when that scanner is disabled
+   - **Flock Row** (below BLE count): one of three states:
+     - `FLOCK:N` inverted (black-on-white) — Flock devices detected this session
+     - `[FLOCK ONLY]` — flock-only mode active, no Flock devices found yet
+     - blank — normal mode, no Flock devices seen
      - Full-screen blinking "GET FLOCKED!" alert fires for 3 seconds on first detection of each new Flock device
      - Display update rate increases to 250ms during alert for smooth blinking, then returns to 1000ms
    - **Center Right**: Animated WiFi logo
@@ -114,15 +121,20 @@ The sketch is structured around four main components:
    - All display elements use consistent 2px margins on left and right edges
 
 5. **Flock Safety Detection** (`isFlockWiFi()` / `isFlockBLE()` functions):
-   - Identifies Flock Safety (SoundThinking) license plate readers and Raven acoustic sensors
-   - Signatures sourced from `github.com/MaxwellDPS/Flock-You-Android`
-   - WiFi detection: SSID prefix matching (`flock`, `fs-`, `fs_`, `falcon`, `sparrow`, `condor`) + Quectel/Telit LTE modem OUIs
-   - BLE detection: device name prefix matching + Raven-specific service UUIDs (`0000310x`–`0000350x`)
+   - Identifies Flock Safety (SoundThinking) license plate readers, Penguin external batteries, and Raven acoustic sensors
+   - Signatures sourced from `github.com/MaxwellDPS/Flock-You-Android` and `github.com/justcallmekoko/ESP32Marauder`
+   - WiFi SSID prefixes: `flock`, `fs-`, `fs_`, `falcon`, `sparrow`, `condor`, `penguin`, `pigvision`, `fs ext batt`
+   - WiFi OUIs: Quectel (`50:29:4D`, `86:25:19`), Telit (`00:14:2D`, `D8:C7:71`), Flock Safety direct (`B4:1E:52`)
+   - BLE name prefixes: `flock`, `falcon`, `raven`, `penguin-`, `fs ext batt`, `soundthinking`, `shotspotter`
+   - BLE service UUIDs (firmware 1.2.x+): `0000310x`–`0000350x`; legacy (1.1.x): `00001809`, `00001819`
+   - BLE manufacturer data: Xuntong company ID `0x09C8` (hex prefix `C809`) — Penguin battery ODM chip
+   - `isFlockBLE()` takes three args: `name`, `serviceUUID`, `manufDataHex`
    - Detected devices are logged as `FLOCK-WIFI` or `FLOCK-BLE` (instead of `WIFI`/`BLE`) in the log file
    - `uniqueFlockCount` tracked separately from WiFi/BLE counts
    - On new detection: sets `flockAlertUntilMs = millis() + 3000` to trigger full-screen blinking display alert
    - Display shows `FLOCK:N` in inverted text (black-on-white) persistently while `uniqueFlockCount > 0`
    - Display update interval drops to 250ms during Flock alert (instead of 1000ms) for smooth blinking
+   - **Flock-only mode** (`flockOnlyMode` bool, NVS key `"flockonly"`): when true, non-Flock devices are skipped via `continue` immediately after detection check in both `scanWiFi()` and `scanBluetooth()` — nothing counted, logged, or displayed for non-Flock hits
 
 6. **Device Tracking**:
    - Maintains count of unique WiFi devices seen (by BSSID)
@@ -170,6 +182,7 @@ Key settings defined at the top of the sketch:
 - **Scanner Flags** (runtime `bool` variables, persisted in NVS via `Preferences`):
   - `enableWifiScan`: Enable/disable WiFi network scanning (default: true)
   - `enableBleScan`: Enable/disable Bluetooth Low Energy scanning (default: true)
+  - `flockOnlyMode`: When true, non-Flock devices are silently ignored — not counted, not logged (default: false)
   - These are changed at runtime via the pause/settings menu and survive reboots
   - Previously these were compile-time `#define` constants; do NOT revert to defines
 
@@ -206,7 +219,7 @@ Key settings defined at the top of the sketch:
   - **At boot**: hold button during power-on → file sharing mode (2-second window)
   - **During scan**: hold 1 second → pause (flushes SD, opens settings menu)
   - **In settings menu**: short tap (<1s) advances cursor; hold 1s activates selected item
-    - Menu items: `WiFi: ON/OFF`, `BLE: ON/OFF`, `Resume Scan`
+    - Menu items: `WiFi: ON/OFF`, `BLE: ON/OFF`, `Flock: ON/OFF`, `Resume Scan` (4 items, cursor wraps)
     - Selected item shown inverted on OLED
     - Toggles are saved to NVS immediately
   - Device boots into scan mode by default (waits for GPS signal)
@@ -340,8 +353,8 @@ The device has two primary operating modes:
    - Display shows real-time GPS data, device counts, and scanning status
    - **Pause + settings**: Hold mode button 1 second → pauses scanning, drains log queue,
      waits for last SD write, then shows settings menu. In menu: short tap advances cursor
-     through WiFi toggle / BLE toggle / Resume; long hold activates selection. Settings
-     persist to NVS (survive reboot).
+     through WiFi toggle / BLE toggle / Flock-only toggle / Resume; long hold activates selection.
+     Settings persist to NVS (survive reboot).
 
 2. **File Sharing Mode:**
    - Selected at boot: hold the mode button while powering on (2-second window shown on display)

--- a/README.md
+++ b/README.md
@@ -77,10 +77,46 @@ The OLED display provides real-time visual feedback, updating every 1 second:
   - First number = devices found in last scan
   - Number in parentheses = total unique devices seen since boot
   - **Asterisk (*)** appears when actively scanning (e.g., "W:5(23)*" during WiFi scan)
+  - **`W:--` / `B:--`** shown when WiFi or BLE scanning is disabled
 - **Center Right:** Animated WiFi logo
-- **Flock Alert Row:** `FLOCK:N` shown inverted (black-on-white) when any Flock Safety device has been detected. A full-screen blinking "GET FLOCKED!" alert appears for 3 seconds on first detection of each new device.
+- **Flock Row:** Shows one of three states:
+  - `FLOCK:N` inverted (black-on-white) — one or more Flock devices detected this session
+  - `[FLOCK ONLY]` — Flock-only mode is active but no devices found yet
+  - *(blank)* — normal mode, no Flock devices seen
+  - A full-screen blinking "GET FLOCKED!" alert appears for 3 seconds on first detection of each new device.
 - **Bottom Left:** Current UTC time from GPS in HH:MM:SS format (2px left margin, updates every second)
 - **Bottom Right:** Current speed in MPH and KPH format (2px right margin, right-aligned)
+
+## Pre-built Firmware
+
+Every tagged release on GitHub includes ready-to-flash firmware built automatically by GitHub Actions. No Arduino IDE required to flash.
+
+### Files in each release
+
+| File | Use |
+|------|-----|
+| `SignalScout-merged.bin` | **Recommended** — single file, flash at address `0x0` |
+| `SignalScout.ino.bin` | App only — flash at `0x10000` |
+| `SignalScout.ino.bootloader.bin` | Bootloader — flash at `0x0` |
+| `SignalScout.ino.partitions.bin` | Partition table — flash at `0x8000` |
+
+### Flashing with esptool.py
+
+```bash
+# Easiest — merged binary, single command
+esptool.py --chip esp32c5 --port /dev/ttyUSB0 write_flash 0x0 SignalScout-merged.bin
+```
+
+### Releasing a new version
+
+Push a tag and GitHub Actions builds and publishes automatically:
+
+```bash
+git tag v1.2.0
+git push origin v1.2.0
+```
+
+The workflow installs arduino-cli, the ESP32 core, and all required libraries, then compiles and attaches the binaries to the release. `secrets.h` is not included in any release binary — you must supply your own WiFi credentials by flashing a build from source, or the file-sharing mode simply won't connect (all other features work without it).
 
 ## Quick Start Guide
 
@@ -199,6 +235,7 @@ The push button on GPIO23 serves different functions depending on **when** you p
 **Settings menu items:**
 - `WiFi: ON/OFF` — toggle WiFi scanning (saved to flash, survives reboot)
 - `BLE: ON/OFF` — toggle BLE scanning (saved to flash, survives reboot)
+- `Flock: ON/OFF` — toggle Flock-only mode; when ON, non-Flock devices are ignored entirely (not counted, not logged)
 - `Resume Scan` — exit settings and resume scanning
 
 The currently selected item is shown inverted on the display. Pausing flushes the SD card log queue before opening the menu so no data is lost.
@@ -236,20 +273,33 @@ const char* WIFI_PASSWORD = "YourNetworkPassword";
 
 ## Flock Safety Detection
 
-SignalScout automatically identifies **Flock Safety** (now SoundThinking) license plate readers and Raven acoustic gunshot sensors while scanning. These are fixed surveillance cameras commonly found on utility poles and street furniture.
+SignalScout automatically identifies **Flock Safety** (now SoundThinking) license plate readers, Penguin external battery packs, and Raven acoustic gunshot sensors while scanning. These are fixed surveillance devices commonly found on utility poles and street furniture.
 
-Signatures are sourced from [MaxwellDPS/Flock-You-Android](https://github.com/MaxwellDPS/Flock-You-Android).
+Signatures are sourced from [MaxwellDPS/Flock-You-Android](https://github.com/MaxwellDPS/Flock-You-Android) and [justcallmekoko/ESP32Marauder](https://github.com/justcallmekoko/ESP32Marauder).
 
 ### What It Detects
 
 **WiFi (via SSID prefix or hardware OUI):**
-- SSID prefixes: `flock`, `fs-`, `fs_`, `falcon`, `sparrow`, `condor`
+- SSID prefixes: `flock`, `fs-`, `fs_`, `falcon`, `sparrow`, `condor`, `penguin`, `pigvision`, `fs ext batt`
 - Quectel LTE modem OUIs: `50:29:4D`, `86:25:19`
 - Telit LTE modem OUIs: `00:14:2D`, `D8:C7:71`
+- Flock Safety registered OUI: `B4:1E:52`
 
-**BLE (via device name or service UUID):**
-- Device name prefixes: `flock`, `falcon`, `raven`
-- Raven service UUIDs: `00003100` (GPS Location), `00003200` (Power Management), `00003300` (Audio/Detection), `00003400` (Config/Status), `00003500` (Error/Diagnostics)
+**BLE (via device name, service UUID, or manufacturer data):**
+- Device name prefixes: `flock`, `falcon`, `raven`, `penguin-`, `fs ext batt`, `soundthinking`, `shotspotter`
+- Raven service UUIDs (firmware 1.2.x+): `00003100` (GPS Location), `00003200` (Power Management), `00003300` (Network Status), `00003400` (Upload Statistics), `00003500` (Error/Diagnostics)
+- Legacy Raven service UUIDs (firmware 1.1.x): `00001809`, `00001819`
+- Xuntong manufacturer data (`C809` prefix) — identifies Flock Penguin external battery packs by ODM chip
+
+### Flock-Only Mode
+
+Enable **Flock-only mode** from the pause/settings menu (`Flock: ON`) to filter out all non-Flock devices. When active:
+- WiFi and BLE scans still run normally
+- Any device that doesn't match a Flock signature is silently ignored — not counted, not logged, not displayed
+- The display shows `[FLOCK ONLY]` in the stats area until a Flock device is found
+- The setting persists across reboots (saved to flash)
+
+This mode is useful when you're specifically hunting for Flock cameras and don't want surrounding noise cluttering your log.
 
 ### Visual Alerts
 
@@ -358,6 +408,7 @@ The pause/settings menu lets you toggle scanning modes at runtime without reflas
 
 - **WiFi scanning** — enable or disable WiFi scanning
 - **BLE scanning** — enable or disable BLE scanning
+- **Flock-only mode** — when enabled, ignore all non-Flock devices (nothing counted or logged)
 
 ## Troubleshooting
 

--- a/SignalScout.ino
+++ b/SignalScout.ino
@@ -78,8 +78,9 @@
 #define BLE_SCAN_TIME 3      // BLE scan duration in seconds
 
 // Scanner enable/disable flags (runtime bools, persisted in NVS, changeable via pause menu)
-bool enableWifiScan = true;  // Enable/disable WiFi scanning
-bool enableBleScan  = true;  // Enable/disable BLE scanning
+bool enableWifiScan = true;   // Enable/disable WiFi scanning
+bool enableBleScan  = true;   // Enable/disable BLE scanning
+bool flockOnlyMode  = false;  // When true, ignore all non-Flock devices
 
 // Output enable/disable flags
 #define ENABLE_CONSOLE_OUTPUT false   // Enable/disable serial console output
@@ -189,7 +190,7 @@ bool fileSharingMode = false;
 bool scanMode = false;
 bool scanTasksStarted = false;
 bool scanPaused = false;  // Scan paused for safe power-off (button hold in scan mode)
-int  pauseMenuCursor = 0; // 0=WiFi toggle, 1=BLE toggle, 2=Resume
+int  pauseMenuCursor = 0; // 0=WiFi toggle, 1=BLE toggle, 2=Flock Only toggle, 3=Resume
 Preferences prefs;        // NVS key-value store for settings persistence
 unsigned long gpsWaitStart = 0; // When GPS wait began (for elapsed time display)
 int gpsWaitDotCount = 0;        // Dot animation counter for GPS wait console output
@@ -313,18 +314,22 @@ void ledFileSharing() {
 // Load scanner settings from NVS (called once at boot)
 void loadSettings() {
   prefs.begin("scout", true);  // true = read-only
-  enableWifiScan = prefs.getBool("wifi", true);
-  enableBleScan  = prefs.getBool("ble",  true);
+  enableWifiScan = prefs.getBool("wifi",      true);
+  enableBleScan  = prefs.getBool("ble",       true);
+  flockOnlyMode  = prefs.getBool("flockonly", false);
   prefs.end();
-  consolePrintf("Settings loaded: WiFi=%s, BLE=%s\n",
-                enableWifiScan ? "ON" : "OFF", enableBleScan ? "ON" : "OFF");
+  consolePrintf("Settings loaded: WiFi=%s, BLE=%s, FlockOnly=%s\n",
+                enableWifiScan ? "ON" : "OFF",
+                enableBleScan  ? "ON" : "OFF",
+                flockOnlyMode  ? "ON" : "OFF");
 }
 
 // Save scanner settings to NVS (called when user changes a toggle)
 void saveSettings() {
   prefs.begin("scout", false);  // false = read-write
-  prefs.putBool("wifi", enableWifiScan);
-  prefs.putBool("ble",  enableBleScan);
+  prefs.putBool("wifi",      enableWifiScan);
+  prefs.putBool("ble",       enableBleScan);
+  prefs.putBool("flockonly", flockOnlyMode);
   prefs.end();
 }
 
@@ -963,7 +968,7 @@ void loop() {
       } else {
         // Paused / settings menu: short tap advances cursor, long press activates
         if (holdDuration < SHARE_HOLD_TIME) {
-          pauseMenuCursor = (pauseMenuCursor + 1) % 3;
+          pauseMenuCursor = (pauseMenuCursor + 1) % 4;
         } else {
           activatePauseMenuItem();
         }
@@ -1042,7 +1047,12 @@ void activatePauseMenuItem() {
       saveSettings();
       consolePrintf("BLE scanning %s\n", enableBleScan ? "enabled" : "disabled");
       break;
-    case 2:  // Resume
+    case 2:  // Toggle Flock Only
+      flockOnlyMode = !flockOnlyMode;
+      saveSettings();
+      consolePrintf("Flock-only mode %s\n", flockOnlyMode ? "enabled" : "disabled");
+      break;
+    case 3:  // Resume
       resumeScanning();
       break;
   }
@@ -1057,28 +1067,38 @@ void updateDisplayPaused() {
   display.println("== PAUSED / SETTINGS ==");
 
   // Menu item 0: WiFi toggle
-  display.setCursor(2, 13);
+  display.setCursor(2, 11);
   if (pauseMenuCursor == 0) {
     display.setTextColor(SSD1306_BLACK, SSD1306_WHITE);  // Inverted = selected
-    display.printf(" WiFi: %-3s ", enableWifiScan ? "ON" : "OFF");
+    display.printf(" WiFi:  %-3s ", enableWifiScan ? "ON" : "OFF");
     display.setTextColor(SSD1306_WHITE);
   } else {
-    display.printf("  WiFi: %-3s ", enableWifiScan ? "ON" : "OFF");
+    display.printf("  WiFi:  %-3s ", enableWifiScan ? "ON" : "OFF");
   }
 
   // Menu item 1: BLE toggle
-  display.setCursor(2, 25);
+  display.setCursor(2, 21);
   if (pauseMenuCursor == 1) {
     display.setTextColor(SSD1306_BLACK, SSD1306_WHITE);
-    display.printf(" BLE:  %-3s ", enableBleScan ? "ON" : "OFF");
+    display.printf(" BLE:   %-3s ", enableBleScan ? "ON" : "OFF");
     display.setTextColor(SSD1306_WHITE);
   } else {
-    display.printf("  BLE:  %-3s ", enableBleScan ? "ON" : "OFF");
+    display.printf("  BLE:   %-3s ", enableBleScan ? "ON" : "OFF");
   }
 
-  // Menu item 2: Resume
-  display.setCursor(2, 37);
+  // Menu item 2: Flock Only toggle
+  display.setCursor(2, 31);
   if (pauseMenuCursor == 2) {
+    display.setTextColor(SSD1306_BLACK, SSD1306_WHITE);
+    display.printf(" Flock: %-3s ", flockOnlyMode ? "ON" : "OFF");
+    display.setTextColor(SSD1306_WHITE);
+  } else {
+    display.printf("  Flock: %-3s ", flockOnlyMode ? "ON" : "OFF");
+  }
+
+  // Menu item 3: Resume
+  display.setCursor(2, 41);
+  if (pauseMenuCursor == 3) {
     display.setTextColor(SSD1306_BLACK, SSD1306_WHITE);
     display.print(" Resume Scan ");
     display.setTextColor(SSD1306_WHITE);
@@ -1087,8 +1107,8 @@ void updateDisplayPaused() {
   }
 
   // Hint at bottom
-  display.setCursor(2, 54);
-  display.print("Tap=next  Hold=select");
+  display.setCursor(2, 56);
+  display.print("Tap=next  Hold=sel");
 
   display.display();
 }
@@ -1850,6 +1870,7 @@ String getAuthModeString(wifi_auth_mode_t authMode) {
 
 // --- Flock Safety Device Detection ---
 // Signatures sourced from github.com/MaxwellDPS/Flock-You-Android
+// and github.com/justcallmekoko/ESP32Marauder
 
 static bool startsWithCI(const char* str, const char* prefix) {
   return strncasecmp(str, prefix, strlen(prefix)) == 0;
@@ -1858,33 +1879,48 @@ static bool startsWithCI(const char* str, const char* prefix) {
 // Returns true if WiFi AP matches Flock Safety signatures (SSID or OUI)
 bool isFlockWiFi(const char* ssid, uint8_t* bssid) {
   // SSID patterns (case-insensitive prefix match)
-  if (startsWithCI(ssid, "flock"))   return true;
-  if (startsWithCI(ssid, "fs-"))     return true;
-  if (startsWithCI(ssid, "fs_"))     return true;
-  if (startsWithCI(ssid, "falcon"))  return true;
-  if (startsWithCI(ssid, "sparrow")) return true;
-  if (startsWithCI(ssid, "condor"))  return true;
+  if (startsWithCI(ssid, "flock"))        return true;
+  if (startsWithCI(ssid, "fs-"))          return true;
+  if (startsWithCI(ssid, "fs_"))          return true;
+  if (startsWithCI(ssid, "falcon"))       return true;
+  if (startsWithCI(ssid, "sparrow"))      return true;
+  if (startsWithCI(ssid, "condor"))       return true;
+  if (startsWithCI(ssid, "penguin"))      return true;   // Flock external battery AP
+  if (startsWithCI(ssid, "pigvision"))    return true;   // Flock camera firmware variant
+  if (startsWithCI(ssid, "fs ext batt")) return true;   // "FS Ext Battery" AP name
   // Quectel LTE modem OUI (primary Flock modem manufacturer)
   if (bssid[0]==0x50 && bssid[1]==0x29 && bssid[2]==0x4D) return true;
   if (bssid[0]==0x86 && bssid[1]==0x25 && bssid[2]==0x19) return true;
   // Telit LTE modem OUI (alternate Flock modem)
   if (bssid[0]==0x00 && bssid[1]==0x14 && bssid[2]==0x2D) return true;
   if (bssid[0]==0xD8 && bssid[1]==0xC7 && bssid[2]==0x71) return true;
+  // OUI registered directly to Flock Safety
+  if (bssid[0]==0xB4 && bssid[1]==0x1E && bssid[2]==0x52) return true;
   return false;
 }
 
-// Returns true if BLE device matches Flock Safety signatures (name or Raven service UUID)
-bool isFlockBLE(const char* name, const char* serviceUUID) {
+// Returns true if BLE device matches Flock Safety signatures (name, service UUID, or manufacturer data)
+// manufDataHex: hex string of raw manufacturer data bytes (first 2 bytes = company ID, little-endian)
+bool isFlockBLE(const char* name, const char* serviceUUID, const char* manufDataHex) {
   // BLE name patterns (case-insensitive prefix match)
-  if (startsWithCI(name, "flock"))  return true;
-  if (startsWithCI(name, "falcon")) return true;
-  if (startsWithCI(name, "raven"))  return true;  // Raven acoustic sensor (Flock/SoundThinking)
-  // Raven custom BLE service UUIDs
+  if (startsWithCI(name, "flock"))        return true;
+  if (startsWithCI(name, "falcon"))       return true;
+  if (startsWithCI(name, "raven"))        return true;  // Raven acoustic sensor
+  if (startsWithCI(name, "penguin-"))     return true;  // Flock Penguin external battery (old firmware)
+  if (startsWithCI(name, "fs ext batt")) return true;  // Flock external battery (legacy name)
+  if (startsWithCI(name, "soundthinking")) return true; // SoundThinking (parent company) rebranding
+  if (startsWithCI(name, "shotspotter"))  return true;  // ShotSpotter acoustic sensor (SoundThinking)
+  // Raven custom BLE service UUIDs (firmware 1.2.x+)
   if (serviceUUID && strstr(serviceUUID, "00003100") != NULL) return true;  // GPS Location
   if (serviceUUID && strstr(serviceUUID, "00003200") != NULL) return true;  // Power Management
   if (serviceUUID && strstr(serviceUUID, "00003300") != NULL) return true;  // Network Status
   if (serviceUUID && strstr(serviceUUID, "00003400") != NULL) return true;  // Upload Statistics
   if (serviceUUID && strstr(serviceUUID, "00003500") != NULL) return true;  // Error/Diagnostics
+  // Legacy Raven BLE service UUIDs (firmware 1.1.x)
+  if (serviceUUID && strstr(serviceUUID, "00001809") != NULL) return true;  // Health Thermometer profile
+  if (serviceUUID && strstr(serviceUUID, "00001819") != NULL) return true;  // Location/Navigation profile
+  // Xuntong company ID 0x09C8 (LE bytes: C8 09) — Flock Penguin ODM manufacturer
+  if (manufDataHex && startsWithCI(manufDataHex, "C809")) return true;
   return false;
 }
 
@@ -1963,6 +1999,9 @@ bool scanWiFi() {
     // Flock Safety detection
     bool isFlock = isFlockWiFi(ssid.c_str(), ap->bssid);
     if (isFlock) flockLastSeenMs = millis();
+
+    // In Flock-only mode, skip all non-Flock devices entirely
+    if (flockOnlyMode && !isFlock) continue;
 
     // Track unique devices by BSSID (with mutex protection)
     if (xSemaphoreTake(deviceMapMutex, portMAX_DELAY) == pdTRUE) {
@@ -2078,9 +2117,12 @@ void scanBluetooth() {
       serviceUUID = device.getServiceUUID().toString().c_str();
     }
 
-    // Flock Safety detection (full name + UUID check)
-    bool isFlock = isFlockBLE(name.c_str(), serviceUUID.c_str());
+    // Flock Safety detection (full name + UUID + manufacturer data check)
+    bool isFlock = isFlockBLE(name.c_str(), serviceUUID.c_str(), manufData.c_str());
     if (isFlock) flockLastSeenMs = millis();
+
+    // In Flock-only mode, skip all non-Flock devices entirely
+    if (flockOnlyMode && !isFlock) continue;
 
     // Track unique devices by address (with mutex protection)
     if (xSemaphoreTake(deviceMapMutex, portMAX_DELAY) == pdTRUE) {
@@ -2327,28 +2369,35 @@ void updateDisplay(String statusMessage) {
     int wifi_total = cached_wifi_total;
     int ble_total = cached_ble_total;
 
-    // WiFi count: Last scan (Total) - add asterisk when scanning
+    // WiFi count: Last scan (Total) - add asterisk when scanning, "--" when disabled
     display.setCursor(2, 22);
-    if (wifiScanning) {
+    if (!enableWifiScan) {
+      display.print("W:--");
+    } else if (wifiScanning) {
       display.printf("W:%d(%d)*", wifi_last, wifi_total);
     } else {
       display.printf("W:%d(%d)", wifi_last, wifi_total);
     }
 
-    // BLE count: Last scan (Total) - add asterisk when scanning
+    // BLE count: Last scan (Total) - add asterisk when scanning, "--" when disabled
     display.setCursor(2, 34);
-    if (bleScanning) {
+    if (!enableBleScan) {
+      display.print("B:--");
+    } else if (bleScanning) {
       display.printf("B:%d(%d)*", ble_last, ble_total);
     } else {
       display.printf("B:%d(%d)", ble_last, ble_total);
     }
 
-    // Flock Safety alert - inverted text at y=46 when any Flock device detected
+    // Flock row at y=46: inverted count when devices seen; plain mode label when flock-only active
     if (cached_flock_total > 0) {
       display.setTextColor(SSD1306_BLACK, SSD1306_WHITE);  // Inverted: alert style
       display.setCursor(2, 46);
       display.printf("FLOCK:%d", cached_flock_total);
       display.setTextColor(SSD1306_WHITE);  // Reset
+    } else if (flockOnlyMode) {
+      display.setCursor(2, 46);
+      display.print("[FLOCK ONLY]");
     }
 
     // Draw animated WiFi logo in center-right of screen


### PR DESCRIPTION
## Summary

- **Flock-only mode** — new runtime setting (`Flock: ON/OFF` in the pause/settings menu, persisted in NVS). When enabled, non-Flock devices are silently skipped in both scan loops: nothing counted, logged, or shown on display. Display shows `[FLOCK ONLY]` until a Flock device is found.
- **Expanded Flock detection signatures** from ESP32Marauder + Flock-You-Android:
  - WiFi SSIDs: `penguin`, `pigvision`, `fs ext batt`
  - WiFi OUI: `B4:1E:52` (registered directly to Flock Safety)
  - BLE names: `penguin-`, `fs ext batt`, `soundthinking`, `shotspotter`
  - BLE service UUIDs: `00001809`, `00001819` (legacy Raven firmware 1.1.x)
  - BLE manufacturer data: Xuntong `C809` prefix (Flock Penguin battery ODM chip)
- **Display indicators** — `W:--` / `B:--` when a scanner is disabled; `[FLOCK ONLY]` label in stats area when flock-only mode is active
- **GitHub Actions CI** (`.github/workflows/build-release.yml`) — compiles with arduino-cli on every `v*` tag push, merges bootloader + partition table + app into a single flashable binary, and publishes a GitHub Release with all bin files attached. `workflow_dispatch` allows test builds without tagging.

## Test plan

- [ ] Merge to main and push a `v*` tag to verify the Actions workflow triggers and produces a release
- [ ] Manually trigger `workflow_dispatch` to test the build without a tag
- [ ] Verify settings menu shows 4 items and `Flock: ON/OFF` toggles correctly on device
- [ ] Verify `W:--` / `B:--` appear on display when scanners are disabled
- [ ] Verify `[FLOCK ONLY]` label appears when flock-only mode is on and no devices seen

🤖 Generated with [Claude Code](https://claude.com/claude-code)