### PR TITLE
Add more fingerprints for flock

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,6 +13,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        include:
+          # Standard ESP32-C5 dev board: 16MB flash, 8MB PSRAM
+          - name: esp32c5-16mb
+            fqbn: "esp32:esp32:esp32c5:FlashSize=16M,PartitionScheme=huge_app,PSRAM=enabled"
+          # Seeed XIAO ESP32-C5: 8MB flash, 8MB PSRAM
+          - name: xiao-esp32c5-8mb
+            fqbn: "esp32:esp32:esp32c5:FlashSize=8M,PartitionScheme=huge_app,PSRAM=enabled"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -65,13 +75,10 @@ jobs:
           EOF
 
       # ── Compile ───────────────────────────────────────────────────────────
-      # The repo root is the sketch directory (SignalScout.ino lives here).
-      # Board: ESP32-C5 (16 MB flash, 8 MB PSRAM).
-      # Adjust FlashSize / PSRAM options if your hardware differs.
-      - name: Compile sketch
+      - name: Compile sketch (${{ matrix.name }})
         run: |
           arduino-cli compile \
-            --fqbn "esp32:esp32:esp32c5:FlashSize=16M,PartitionScheme=huge_app,PSRAM=enabled" \
+            --fqbn "${{ matrix.fqbn }}" \
             --export-binaries \
             --output-dir build \
             .
@@ -80,13 +87,13 @@ jobs:
         run: ls -lh build/
 
       # ── Merge into a single flashable binary ──────────────────────────────
-      # Produces SignalScout-merged.bin that can be flashed at address 0x0
+      # Produces SignalScout-<target>-merged.bin flashable at address 0x0
       # with esptool.py or the Espressif Flash Download Tool.
       - name: Merge bootloader + partition table + app into one binary
         run: |
           pip install esptool --quiet
           esptool.py --chip esp32c5 merge_bin \
-            --output build/SignalScout-merged.bin \
+            --output build/SignalScout-${{ matrix.name }}-merged.bin \
             0x0     build/SignalScout.ino.bootloader.bin \
             0x8000  build/SignalScout.ino.partitions.bin \
             0x10000 build/SignalScout.ino.bin
@@ -95,12 +102,12 @@ jobs:
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
-          name: SignalScout-firmware-${{ github.ref_name || github.sha }}
+          name: SignalScout-${{ matrix.name }}-${{ github.ref_name || github.sha }}
           path: |
             build/SignalScout.ino.bin
             build/SignalScout.ino.bootloader.bin
             build/SignalScout.ino.partitions.bin
-            build/SignalScout-merged.bin
+            build/SignalScout-${{ matrix.name }}-merged.bin
 
       # ── GitHub Release (tag pushes only) ──────────────────────────────────
       - name: Create GitHub Release
@@ -110,7 +117,7 @@ jobs:
           name: "SignalScout ${{ github.ref_name }}"
           generate_release_notes: true
           files: |
-            build/SignalScout-merged.bin
+            build/SignalScout-${{ matrix.name }}-merged.bin
             build/SignalScout.ino.bin
             build/SignalScout.ino.bootloader.bin
             build/SignalScout.ino.partitions.bin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,8 @@ The sketch is structured around four main components:
    - Identifies Flock Safety (SoundThinking) license plate readers, Penguin external batteries, and Raven acoustic sensors
    - Signatures sourced from `github.com/MaxwellDPS/Flock-You-Android` and `github.com/justcallmekoko/ESP32Marauder`
    - WiFi SSID prefixes: `flock`, `fs-`, `fs_`, `falcon`, `sparrow`, `condor`, `penguin`, `pigvision`, `fs ext batt`
-   - WiFi OUIs: Quectel (`50:29:4D`, `86:25:19`), Telit (`00:14:2D`, `D8:C7:71`), Flock Safety direct (`B4:1E:52`)
-   - BLE name prefixes: `flock`, `falcon`, `raven`, `penguin-`, `fs ext batt`, `soundthinking`, `shotspotter`
+   - WiFi OUIs: 36 total — 31 field-verified entries from colonelpanichacks/flock-you plus Quectel (`50:29:4D`, `86:25:19`), Telit (`00:14:2D`, `D8:C7:71`), and Flock Safety direct (`B4:1E:52`) from MaxwellDPS/ESP32Marauder research
+   - BLE name prefixes: `flock`, `falcon`, `raven`, `penguin` (any variant), `pigvision`, `fs ext batt`, `soundthinking`, `shotspotter`
    - BLE service UUIDs (firmware 1.2.x+): `0000310x`–`0000350x`; legacy (1.1.x): `00001809`, `00001819`
    - BLE manufacturer data: Xuntong company ID `0x09C8` (hex prefix `C809`) — Penguin battery ODM chip
    - `isFlockBLE()` takes three args: `name`, `serviceUUID`, `manufDataHex`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Power off when done; boot normally (button released) to return to scan mode
 
 Hardware requirements:
-- ESP32-C5 board (16MB FLASH, 8MB PSRAM)
+- ESP32-C5 board (16MB FLASH, 8MB PSRAM) **or** Seeed Studio XIAO ESP32-C5 (8MB FLASH, 8MB PSRAM — use the `xiao-esp32c5-8mb` CI artifact)
 - SD card module connected via SPI
 - NEO-6M GPS module connected via UART (TX/RX)
 - SSD1309 OLED display 128x64 connected via SPI
@@ -40,7 +40,9 @@ This is an Arduino sketch (.ino file) that should be developed using:
 - Arduino CLI, or
 - PlatformIO
 
-**CI/CD:** GitHub Actions (`.github/workflows/build-release.yml`) compiles the sketch on every `v*` tag push using arduino-cli + the ESP32 core, then creates a GitHub Release with the compiled binaries attached. Push a tag (`git tag vX.Y.Z && git push origin vX.Y.Z`) to trigger a release. `workflow_dispatch` allows manual test builds without tagging. The workflow creates a stub `secrets.h` at compile time (empty credentials) — the gitignored real file is never committed or embedded in releases.
+**CI/CD:** GitHub Actions (`.github/workflows/build-release.yml`) compiles the sketch on every `v*` tag push using arduino-cli + the ESP32 core, then creates a GitHub Release with the compiled binaries attached. Push a tag (`git tag vX.Y.Z && git push origin vX.Y.Z`) to trigger a release. `workflow_dispatch` allows manual test builds without tagging. The workflow creates a stub `secrets.h` at compile time (empty credentials) — the gitignored real file is never committed or embedded in releases. Two build targets use a matrix strategy:
+- `esp32c5-16mb` — standard ESP32-C5 dev board (16MB flash, PSRAM enabled)
+- `xiao-esp32c5-8mb` — Seeed XIAO ESP32-C5 (8MB flash, PSRAM disabled)
 
 ## File Structure
 
@@ -64,15 +66,15 @@ The sketch uses FreeRTOS tasks for concurrent execution on the ESP32-C5's single
 - Higher priority tasks preempt lower priority tasks when ready to run
 
 **Thread Safety & Radio Sequencing:**
-- **Mutexes**: Protect shared resources (device maps, SD card access, display)
+- **Mutexes**: Protect shared resources (device maps including `seenFlockKeys`, SD card access, display)
 - **Queue System**: Non-blocking log entry queue (50 entries) prevents SD card write conflicts
 - **Sequential Scanning**: WiFi and BLE scans run back-to-back within a single unified task. The ESP32-C5 hardware coexistence arbiter handles radio sharing automatically — BLE is initialized once and kept alive across cycles (NOT deinit/reinit per cycle, which corrupted radio state after 3-5 cycles):
   - WiFi: Runs first (~3 seconds); `esp_wifi_clear_ap_list()` called after `WIFI_STA` mode is confirmed active (NOT before, when driver is off)
   - BLE: Runs after WiFi completes (~3 seconds); `pBLEScan->stop()` called explicitly after the blocking `start()` returns, then `pBLEScan->clearResults()`, then 500ms delay to let the radio fully release
   - BLE scan duty cycle: interval=100ms, window=50ms (50%) — leaving 50% radio time for coexistence arbiter (previously 99%, which starved the arbiter)
   - Cycle repeats every 10 seconds
-- **WiFi Failure Recovery**: consecutive WiFi scan failures are tracked; after 3 failures a deep `esp_wifi_stop()` + `esp_wifi_start()` reset is performed automatically. Zero-AP results (silent driver failure) are also tracked — 5 consecutive zero-AP scans force recovery the same way.
-- **Proactive WiFi Driver Reset**: regardless of failure state, the driver is fully reset every `WIFI_DRIVER_RESET_INTERVAL_MS` (default 5 minutes) to prevent silent degradation that causes scans to stop working after long sessions. This reset runs before the scan setup in each cycle when the interval has elapsed. Adjust the `#define` if degradation occurs sooner.
+- **WiFi Failure Recovery**: consecutive WiFi scan failures are tracked; after 3 failures a deep `WiFi.mode(WIFI_OFF)` + `esp_wifi_stop()` reset is performed. Zero-AP results (silent driver failure) are also tracked — 5 consecutive zero-AP scans force recovery the same way. **Critical**: neither recovery path calls `esp_wifi_start()` directly — `WiFi.mode(WIFI_STA)` in the retry loop handles that. Calling `esp_wifi_start()` here and then `WiFi.mode(WIFI_OFF)` immediately after creates a start→stop→start→stop chain that corrupts the ESP32-C5 radio arbiter.
+- **Proactive WiFi Mode Reset**: regardless of failure state, a `WiFi.mode(WIFI_OFF)` reset is run every `WIFI_DRIVER_RESET_INTERVAL_MS` (default 15 minutes). Uses only `WiFi.mode()` APIs — never `esp_wifi_start()` — for the same reason above. Increase the interval if issues appear sooner; do not reduce below 10 minutes.
 
 The sketch is structured around four main components:
 
@@ -131,8 +133,8 @@ The sketch is structured around four main components:
    - BLE manufacturer data: Xuntong company ID `0x09C8` (hex prefix `C809`) — Penguin battery ODM chip
    - `isFlockBLE()` takes three args: `name`, `serviceUUID`, `manufDataHex`
    - Detected devices are logged as `FLOCK-WIFI` or `FLOCK-BLE` (instead of `WIFI`/`BLE`) in the log file
-   - `uniqueFlockCount` tracked separately from WiFi/BLE counts
-   - On new detection: sets `flockAlertUntilMs = millis() + 3000` to trigger full-screen blinking display alert
+   - `uniqueFlockCount` tracked separately from WiFi/BLE counts; deduplication uses `seenFlockKeys` (`std::set`), a **never-cleared** set independent of the WiFi/BLE maps — prevents re-counting and re-alerting after map eviction
+   - On first detection of a new key: sets `flockAlertUntilMs = millis() + 3000` to trigger full-screen blinking display alert
    - Display shows `FLOCK:N` in inverted text (black-on-white) persistently while `uniqueFlockCount > 0`
    - Display update interval drops to 250ms during Flock alert (instead of 1000ms) for smooth blinking
    - **Flock-only mode** (`flockOnlyMode` bool, NVS key `"flockonly"`): when true, non-Flock devices are skipped via `continue` immediately after detection check in both `scanWiFi()` and `scanBluetooth()` — nothing counted, logged, or displayed for non-Flock hits

--- a/README.md
+++ b/README.md
@@ -278,18 +278,16 @@ const char* WIFI_PASSWORD = "YourNetworkPassword";
 
 SignalScout automatically identifies **Flock Safety** (now SoundThinking) license plate readers, Penguin external battery packs, and Raven acoustic gunshot sensors while scanning. These are fixed surveillance devices commonly found on utility poles and street furniture.
 
-Signatures are sourced from [MaxwellDPS/Flock-You-Android](https://github.com/MaxwellDPS/Flock-You-Android) and [justcallmekoko/ESP32Marauder](https://github.com/justcallmekoko/ESP32Marauder).
+Signatures are sourced from [colonelpanichacks/flock-you](https://github.com/colonelpanichacks/flock-you), [MaxwellDPS/Flock-You-Android](https://github.com/MaxwellDPS/Flock-You-Android), and [justcallmekoko/ESP32Marauder](https://github.com/justcallmekoko/ESP32Marauder).
 
 ### What It Detects
 
 **WiFi (via SSID prefix or hardware OUI):**
 - SSID prefixes: `flock`, `fs-`, `fs_`, `falcon`, `sparrow`, `condor`, `penguin`, `pigvision`, `fs ext batt`
-- Quectel LTE modem OUIs: `50:29:4D`, `86:25:19`
-- Telit LTE modem OUIs: `00:14:2D`, `D8:C7:71`
-- Flock Safety registered OUI: `B4:1E:52`
+- **36 hardware OUIs** — 31 field-verified entries from colonelpanichacks research plus Quectel (`50:29:4D`, `86:25:19`), Telit (`00:14:2D`, `D8:C7:71`), and Flock Safety direct (`B4:1E:52`)
 
 **BLE (via device name, service UUID, or manufacturer data):**
-- Device name prefixes: `flock`, `falcon`, `raven`, `penguin-`, `fs ext batt`, `soundthinking`, `shotspotter`
+- Device name prefixes: `flock`, `falcon`, `raven`, `penguin` (any variant), `pigvision`, `fs ext batt`, `soundthinking`, `shotspotter`
 - Raven service UUIDs (firmware 1.2.x+): `00003100` (GPS Location), `00003200` (Power Management), `00003300` (Network Status), `00003400` (Upload Statistics), `00003500` (Error/Diagnostics)
 - Legacy Raven service UUIDs (firmware 1.1.x): `00001809`, `00001819`
 - Xuntong manufacturer data (`C809` prefix) — identifies Flock Penguin external battery packs by ODM chip

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ SignalScout is a wardriving and wireless reconnaissance tool that scans 2.4GHz a
 
 | Component | Example Model | Connection |
 |-----------|--------------|------------|
-| **Microcontroller** | ESP32-C5 Dev Board (16MB Flash, 8MB PSRAM) | - |
+| **Microcontroller** | ESP32-C5 Dev Board (16MB Flash, 8MB PSRAM) **or** Seeed XIAO ESP32-C5 (8MB Flash, 8MB PSRAM) | - |
 | **GPS Module** | NEO-6M or NEO-7M | UART (RX:14, TX:13) |
 | **OLED Display** | SSD1309 128x64 (or SSD1306) | SPI (MOSI:26, CLK:25, DC:9, CS:8, RST:10) |
 | **SD Card Module** | Micro SD SPI adapter | SPI (MOSI:3, MISO:1, CLK:0, CS:2) |
@@ -89,22 +89,25 @@ The OLED display provides real-time visual feedback, updating every 1 second:
 
 ## Pre-built Firmware
 
-Every tagged release on GitHub includes ready-to-flash firmware built automatically by GitHub Actions. No Arduino IDE required to flash.
+Every tagged release on GitHub includes ready-to-flash firmware built automatically by GitHub Actions for **two targets**. No Arduino IDE required to flash.
 
 ### Files in each release
 
-| File | Use |
-|------|-----|
-| `SignalScout-merged.bin` | **Recommended** — single file, flash at address `0x0` |
-| `SignalScout.ino.bin` | App only — flash at `0x10000` |
-| `SignalScout.ino.bootloader.bin` | Bootloader — flash at `0x0` |
-| `SignalScout.ino.partitions.bin` | Partition table — flash at `0x8000` |
+| File | Target | Use |
+|------|--------|-----|
+| `SignalScout-esp32c5-16mb-merged.bin` | ESP32-C5 dev board (16MB flash) | **Recommended** — single file, flash at `0x0` |
+| `SignalScout-xiao-esp32c5-8mb-merged.bin` | Seeed XIAO ESP32-C5 (8MB flash) | **Recommended for XIAO** — flash at `0x0` |
+| `SignalScout.ino.bin` | (both) | App only — flash at `0x10000` |
+| `SignalScout.ino.bootloader.bin` | (both) | Bootloader — flash at `0x0` |
+| `SignalScout.ino.partitions.bin` | (both) | Partition table — flash at `0x8000` |
 
 ### Flashing with esptool.py
 
 ```bash
-# Easiest — merged binary, single command
-esptool.py --chip esp32c5 --port /dev/ttyUSB0 write_flash 0x0 SignalScout-merged.bin
+# Easiest — merged binary, single command (pick the right file for your board)
+esptool.py --chip esp32c5 --port /dev/ttyUSB0 write_flash 0x0 SignalScout-esp32c5-16mb-merged.bin
+# or for XIAO:
+esptool.py --chip esp32c5 --port /dev/ttyUSB0 write_flash 0x0 SignalScout-xiao-esp32c5-8mb-merged.bin
 ```
 
 ### Releasing a new version
@@ -396,7 +399,7 @@ WiFi credentials for file sharing are stored separately in `secrets.h` (see [Fil
 // Scans run sequentially: WiFi → BLE → repeat
 
 // WiFi driver stability
-#define WIFI_DRIVER_RESET_INTERVAL_MS (5UL * 60UL * 1000UL)  // Proactive reset every 5 min
+#define WIFI_DRIVER_RESET_INTERVAL_MS (15UL * 60UL * 1000UL)  // Proactive mode reset every 15 min
 
 // Battery voltage divider
 #define VOLTAGE_DIVIDER_RATIO 3.333333  // For 200k/100k divider
@@ -418,7 +421,7 @@ The pause/settings menu lets you toggle scanning modes at runtime without reflas
 | **"Waiting GPS" forever** | GPS needs clear sky view, move outdoors, wait up to 2 minutes for cold start |
 | **Display shows nothing** | Verify OLED wiring, check if SSD1309/SSD1306 is set correctly in code |
 | **No WiFi networks found** | Normal in remote areas, verify ESP32 WiFi is working |
-| **WiFi stops working after ~10 min** | The proactive 5-minute driver reset should prevent this; reduce `WIFI_DRIVER_RESET_INTERVAL_MS` if still occurring |
+| **WiFi stops working** | Fixed in firmware — root cause was a start→stop race in the proactive reset. Update to latest firmware. |
 | **Compass shows "---"** | GPS course requires movement >1 km/h, start walking/driving |
 | **LED stays red** | Initialization stuck, check serial monitor for errors |
 | **LED stays orange** | GPS not getting signal, move to open sky area |

--- a/SignalScout.ino
+++ b/SignalScout.ino
@@ -1924,14 +1924,55 @@ bool isFlockWiFi(const char* ssid, uint8_t* bssid) {
   if (startsWithCI(ssid, "penguin"))      return true;   // Flock external battery AP
   if (startsWithCI(ssid, "pigvision"))    return true;   // Flock camera firmware variant
   if (startsWithCI(ssid, "fs ext batt")) return true;   // "FS Ext Battery" AP name
-  // Quectel LTE modem OUI (primary Flock modem manufacturer)
-  if (bssid[0]==0x50 && bssid[1]==0x29 && bssid[2]==0x4D) return true;
-  if (bssid[0]==0x86 && bssid[1]==0x25 && bssid[2]==0x19) return true;
-  // Telit LTE modem OUI (alternate Flock modem)
-  if (bssid[0]==0x00 && bssid[1]==0x14 && bssid[2]==0x2D) return true;
-  if (bssid[0]==0xD8 && bssid[1]==0xC7 && bssid[2]==0x71) return true;
-  // OUI registered directly to Flock Safety
-  if (bssid[0]==0xB4 && bssid[1]==0x1E && bssid[2]==0x52) return true;
+
+  // OUI lookup — inline byte comparison is faster than a loop on embedded hardware.
+  // Sources: colonelpanichacks/flock-you (31 field-verified OUIs), MaxwellDPS/Flock-You-Android,
+  //          justcallmekoko/ESP32Marauder, and FCC filings.
+  uint8_t b0=bssid[0], b1=bssid[1], b2=bssid[2];
+
+  // --- colonelpanichacks/flock-you field-verified OUI list (31 entries) ---
+  if (b0==0x70 && b1==0xC9 && b2==0x4E) return true;
+  if (b0==0x3C && b1==0x91 && b2==0x80) return true;
+  if (b0==0xD8 && b1==0xF3 && b2==0xBC) return true;
+  if (b0==0x80 && b1==0x30 && b2==0x49) return true;
+  if (b0==0xB8 && b1==0x35 && b2==0x32) return true;
+  if (b0==0x14 && b1==0x5A && b2==0xFC) return true;
+  if (b0==0x74 && b1==0x4C && b2==0xA1) return true;
+  if (b0==0x08 && b1==0x3A && b2==0x88) return true;
+  if (b0==0x9C && b1==0x2F && b2==0x9D) return true;
+  if (b0==0xC0 && b1==0x35 && b2==0x32) return true;
+  if (b0==0x94 && b1==0x08 && b2==0x53) return true;
+  if (b0==0xE4 && b1==0xAA && b2==0xEA) return true;
+  if (b0==0xF4 && b1==0x6A && b2==0xDD) return true;
+  if (b0==0xF8 && b1==0xA2 && b2==0xD6) return true;
+  if (b0==0x24 && b1==0xB2 && b2==0xB9) return true;
+  if (b0==0x00 && b1==0xF4 && b2==0x8D) return true;
+  if (b0==0xD0 && b1==0x39 && b2==0x57) return true;
+  if (b0==0xE8 && b1==0xD0 && b2==0xFC) return true;
+  if (b0==0xE0 && b1==0x4F && b2==0x43) return true;
+  if (b0==0xB8 && b1==0x1E && b2==0xA4) return true;
+  if (b0==0x70 && b1==0x08 && b2==0x94) return true;
+  if (b0==0x58 && b1==0x8E && b2==0x81) return true;
+  if (b0==0xEC && b1==0x1B && b2==0xBD) return true;
+  if (b0==0x3C && b1==0x71 && b2==0xBF) return true;
+  if (b0==0x58 && b1==0x00 && b2==0xE3) return true;
+  if (b0==0x90 && b1==0x35 && b2==0xEA) return true;
+  if (b0==0x5C && b1==0x93 && b2==0xA2) return true;
+  if (b0==0x64 && b1==0x6E && b2==0x69) return true;
+  if (b0==0x48 && b1==0x27 && b2==0xEA) return true;
+  if (b0==0xA4 && b1==0xCF && b2==0x12) return true;
+  if (b0==0x82 && b1==0x6B && b2==0xF2) return true;  // DeFlockJoplin field research
+
+  // --- Additional OUIs from MaxwellDPS/ESP32Marauder research ---
+  // Quectel LTE modem (primary Flock modem manufacturer)
+  if (b0==0x50 && b1==0x29 && b2==0x4D) return true;
+  if (b0==0x86 && b1==0x25 && b2==0x19) return true;
+  // Telit LTE modem (alternate Flock modem)
+  if (b0==0x00 && b1==0x14 && b2==0x2D) return true;
+  if (b0==0xD8 && b1==0xC7 && b2==0x71) return true;
+  // OUI registered directly to Flock Safety (FCC filing)
+  if (b0==0xB4 && b1==0x1E && b2==0x52) return true;
+
   return false;
 }
 
@@ -1942,7 +1983,8 @@ bool isFlockBLE(const char* name, const char* serviceUUID, const char* manufData
   if (startsWithCI(name, "flock"))        return true;
   if (startsWithCI(name, "falcon"))       return true;
   if (startsWithCI(name, "raven"))        return true;  // Raven acoustic sensor
-  if (startsWithCI(name, "penguin-"))     return true;  // Flock Penguin external battery (old firmware)
+  if (startsWithCI(name, "penguin"))      return true;  // Flock Penguin external battery (any variant)
+  if (startsWithCI(name, "pigvision"))   return true;  // Flock/Pigvision camera firmware
   if (startsWithCI(name, "fs ext batt")) return true;  // Flock external battery (legacy name)
   if (startsWithCI(name, "soundthinking")) return true; // SoundThinking (parent company) rebranding
   if (startsWithCI(name, "shotspotter"))  return true;  // ShotSpotter acoustic sensor (SoundThinking)

--- a/SignalScout.ino
+++ b/SignalScout.ino
@@ -4,7 +4,7 @@
  * Logs all activity to SD card over SPI with GPS timestamps and location
  * Displays status on SSD1309 OLED display
  *
- * Hardware: ESP32-C5 (16MB FLASH, 8MB PSRAM)
+ * Hardware: ESP32-C5 (16MB FLASH, 8MB PSRAM) or Seeed XIAO ESP32-C5 (8MB FLASH, 8MB PSRAM)
  * SD Card: Connected via SPI
  * GPS: NEO-6M connected via UART (TX/RX)
  * OLED: SSD1309 128x64 connected via SPI
@@ -140,9 +140,12 @@ bool logFileReady = false;
 
 // Device tracking
 #include <map>
+#include <set>
 #include <string>
 std::map<std::string, bool> seenWiFiDevices;    // Track unique WiFi devices by BSSID
 std::map<std::string, bool> seenBLEDevices;     // Track unique BLE devices by address
+// Never cleared — keeps Flock dedup accurate even after WiFi/BLE maps are evicted
+std::set<std::string> seenFlockKeys;
 int uniqueWiFiCount = 0;
 int uniqueBLECount = 0;
 int uniqueFlockCount = 0;
@@ -413,10 +416,13 @@ bool generateLogFileName() {
 // cycles — the ESP32-C5 hardware coexistence arbiter handles radio sharing automatically.
 // Repeatedly calling BLEDevice::init()/deinit() every cycle corrupts radio state after
 // 3-5 cycles, which is what was causing WiFi to hang. Keeping BLE initialized avoids this.
-// Proactive WiFi driver reset interval (ms). The driver silently degrades over long
-// sessions even when scans appear to succeed. Resetting every 5 minutes prevents the
-// 10-minute degradation without being frequent enough to noticeably interrupt scanning.
-#define WIFI_DRIVER_RESET_INTERVAL_MS (5UL * 60UL * 1000UL)
+// Proactive WiFi mode reset interval (ms).
+// Uses WiFi.mode() APIs only — NEVER call esp_wifi_start() inside this reset without
+// immediately setting a mode. The normal scan setup always calls WiFi.mode(WIFI_OFF) right
+// after the proactive block; if esp_wifi_start() was called here, that becomes a
+// start→stop→start chain that corrupts the ESP32-C5 radio and is the root cause of WiFi
+// dying at the ~5-minute mark. 15 minutes avoids constant churn while still refreshing state.
+#define WIFI_DRIVER_RESET_INTERVAL_MS (15UL * 60UL * 1000UL)
 
 void unifiedScanTask(void* parameter) {
   consolePrintln("[Scan Task] Unified scanner started");
@@ -437,17 +443,15 @@ void unifiedScanTask(void* parameter) {
     if (enableWifiScan) {
       consolePrintln("\n[WiFi] Initializing radio...");
 
-      // Proactive deep reset every WIFI_DRIVER_RESET_INTERVAL_MS to prevent silent driver
-      // degradation. This runs before the scan setup so the driver starts each window fresh.
+      // Proactive mode reset: clear stale WiFi state using WiFi.mode() APIs only.
+      // Do NOT call esp_wifi_start() here — the normal scan setup below calls
+      // WiFi.mode(WIFI_OFF) immediately after, turning start→stop→start into a
+      // start→stop→stop→start chain that corrupts the ESP32-C5 radio arbiter.
       if (millis() - lastWifiDriverReset >= WIFI_DRIVER_RESET_INTERVAL_MS) {
         consolePrintln("[WiFi] Scheduled proactive driver reset...");
         WiFi.disconnect(true);
         WiFi.mode(WIFI_OFF);
-        delay(300);
-        esp_wifi_stop();
-        delay(500);
-        esp_wifi_start();
-        delay(500);
+        delay(500);  // Let driver fully stop before normal scan setup takes over
         wifiFailCount = 0;
         lastWifiDriverReset = millis();
         consolePrintln("[WiFi] Proactive reset complete");
@@ -504,12 +508,17 @@ void unifiedScanTask(void* parameter) {
         delay(300);
       }
 
-      // Deep recovery after repeated failures: force full ESP-IDF WiFi driver reset
+      // Deep recovery after repeated failures: force full ESP-IDF WiFi driver stop.
+      // Do NOT call esp_wifi_start() here — WiFi.mode(WIFI_STA) in the next cycle's
+      // retry loop will call it properly with a mode set. Calling start() here without
+      // a mode leaves the driver in an indeterminate state and the subsequent
+      // WiFi.mode(WIFI_OFF) immediately stops it again, corrupting radio state.
       if (wifiFailCount >= 3) {
         consolePrintln("[WiFi] Too many failures - deep radio reset...");
-        esp_wifi_stop();
-        delay(500);
-        esp_wifi_start();
+        WiFi.disconnect(true);
+        WiFi.mode(WIFI_OFF);
+        delay(200);
+        esp_wifi_stop();  // ESP-IDF level stop for stubborn driver state
         delay(500);
         wifiFailCount = 0;
         lastWifiDriverReset = millis();
@@ -806,16 +815,8 @@ void setup() {
   consolePrintln("\n[5b/7] Loading saved settings...");
   loadSettings();
 
-  // Initialize WiFi
-  consolePrintln("\n[6/7] Initializing WiFi...");
-  if (enableWifiScan) {
-    WiFi.mode(WIFI_STA);
-    WiFi.disconnect();
-    delay(100);
-    consolePrintln("WiFi initialized (dual-band 2.4GHz + 5GHz mode)");
-  } else {
-    consolePrintln("WiFi scanning disabled in config");
-  }
+  // WiFi initialized per-cycle by unifiedScanTask (not here — scan task owns the radio)
+  consolePrintln("\n[6/7] WiFi deferred to scan task");
 
   // Skip BLE initialization on boot - it will be initialized by the unified scan task
   consolePrintln("Skipping BLE init (will initialize when scan task starts)");
@@ -1136,6 +1137,23 @@ String formatFileSize(size_t size) {
   return String((float)size / (1024.0 * 1024.0), 1) + " MB";
 }
 
+// HTML-escape a filename for use in HTML attribute values and text content.
+// SD card filenames are firmware-generated and shouldn't contain these chars, but
+// defense-in-depth prevents XSS if someone physically inserts a crafted card.
+void htmlEscapeFilename(const char* src, char* dst, size_t dstSize) {
+  size_t out = 0;
+  for (size_t i = 0; src[i] && out + 7 < dstSize; i++) {
+    char c = src[i];
+    if      (c == '<')  { memcpy(dst + out, "&lt;",   4); out += 4; }
+    else if (c == '>')  { memcpy(dst + out, "&gt;",   4); out += 4; }
+    else if (c == '&')  { memcpy(dst + out, "&amp;",  5); out += 5; }
+    else if (c == '"')  { memcpy(dst + out, "&quot;", 6); out += 6; }
+    else if (c == '\'') { memcpy(dst + out, "&#39;",  5); out += 5; }
+    else                { dst[out++] = c; }
+  }
+  dst[out] = '\0';
+}
+
 // Files per page in web file browser
 #define FILES_PER_PAGE 20
 
@@ -1322,12 +1340,14 @@ void configureServerRoutes() {
                              tm->tm_hour, tm->tm_min);
                   }
                 }
+                char fnameEsc[128];
+                htmlEscapeFilename(fname, fnameEsc, sizeof(fnameEsc));
                 snprintf(rowBuf, sizeof(rowBuf),
                          "<tr><td><a href=\"/download?name=%s\">%s</a></td>"
                          "<td class=\"dt\">%s</td>"
                          "<td class=\"sz\">%s</td>"
                          "<td><button class=\"del\" onclick=\"delFile('%s')\">Delete</button></td></tr>",
-                         fname, fname, dateBuf, sizeStr.c_str(), fname);
+                         fnameEsc, fnameEsc, dateBuf, sizeStr.c_str(), fnameEsc);
                 response->print(rowBuf);
                 filesShown++;
               } else if (fileIndex >= skipCount + FILES_PER_PAGE) {
@@ -1472,7 +1492,7 @@ void configureServerRoutes() {
       return;
     }
     String filename = request->getParam("name")->value();
-    if (filename.indexOf("..") >= 0) {
+    if (filename.indexOf("..") >= 0 || filename.indexOf("/") >= 0) {
       request->send(400, "text/plain", "Invalid filename");
       return;
     }
@@ -1516,9 +1536,11 @@ void configureServerRoutes() {
       String names[MAX_BATCH];
       int count = 0;
 
-      // Process in batches to limit memory usage
+      // Process in batches to limit memory usage. Cap at 100 batches to prevent
+      // an infinite loop if a file can't be deleted (e.g. SD write-protected).
       bool moreFiles = true;
-      while (moreFiles) {
+      int batchLimit = 100;
+      while (moreFiles && batchLimit-- > 0) {
         count = 0;
         root.rewindDirectory();
         // Skip already-processed files by scanning past deleted ones
@@ -1805,25 +1827,23 @@ void startScanTasks() {
 
   // Unified Scan Task - handles WiFi and BLE sequentially
   // Always create the task; it reads enableWifiScan/enableBleScan at runtime each cycle
-  if (true) {
-    if (unifiedScanTaskHandle == NULL) {
-      BaseType_t result = xTaskCreate(
-        unifiedScanTask,       // Task function
-        "Unified Scanner",     // Task name
-        20480,                 // Stack size - BLE library needs significant stack space
-        NULL,                  // Parameters
-        1,                     // Priority
-        &unifiedScanTaskHandle // Task handle
-      );
-      if (result != pdPASS) {
-        consolePrintln("ERROR: Failed to create Unified Scanner task!");
-      } else {
-        consolePrintln("Unified Scanner task created (WiFi->BLE sequential)");
-      }
+  if (unifiedScanTaskHandle == NULL) {
+    BaseType_t result = xTaskCreate(
+      unifiedScanTask,       // Task function
+      "Unified Scanner",     // Task name
+      20480,                 // Stack size - BLE library needs significant stack space
+      NULL,                  // Parameters
+      1,                     // Priority
+      &unifiedScanTaskHandle // Task handle
+    );
+    if (result != pdPASS) {
+      consolePrintln("ERROR: Failed to create Unified Scanner task!");
     } else {
-      vTaskResume(unifiedScanTaskHandle);
-      consolePrintln("Unified Scanner task resumed");
+      consolePrintln("Unified Scanner task created (WiFi->BLE sequential)");
     }
+  } else {
+    vTaskResume(unifiedScanTaskHandle);
+    consolePrintln("Unified Scanner task resumed");
   }
 
   ledReady();  // Green: Ready
@@ -2030,10 +2050,12 @@ bool scanWiFi() {
       if (seenWiFiDevices.find(bssidKey) == seenWiFiDevices.end()) {
         seenWiFiDevices[bssidKey] = true;
         uniqueWiFiCount++;
-        if (isFlock) {
-          uniqueFlockCount++;
-          flockAlertUntilMs = millis() + 3000;
-        }
+      }
+      // Flock dedup uses a separate never-cleared set so map eviction doesn't re-trigger alerts
+      if (isFlock && seenFlockKeys.find(bssidKey) == seenFlockKeys.end()) {
+        seenFlockKeys.insert(bssidKey);
+        uniqueFlockCount++;
+        flockAlertUntilMs = millis() + 3000;
       }
       xSemaphoreGive(deviceMapMutex);
     }
@@ -2151,10 +2173,12 @@ void scanBluetooth() {
       if (seenBLEDevices.find(addrKey) == seenBLEDevices.end()) {
         seenBLEDevices[addrKey] = true;
         uniqueBLECount++;
-        if (isFlock) {
-          uniqueFlockCount++;
-          flockAlertUntilMs = millis() + 3000;
-        }
+      }
+      // Flock dedup uses a separate never-cleared set so map eviction doesn't re-trigger alerts
+      if (isFlock && seenFlockKeys.find(addrKey) == seenFlockKeys.end()) {
+        seenFlockKeys.insert(addrKey);
+        uniqueFlockCount++;
+        flockAlertUntilMs = millis() + 3000;
       }
       xSemaphoreGive(deviceMapMutex);
     }
@@ -2211,7 +2235,6 @@ void scanBluetooth() {
     }
   }
 
-  pBLEScan->clearResults();
   consolePrintln("--- Bluetooth Scan Complete ---\n");
 }
 
@@ -2604,7 +2627,7 @@ void drawWiFiLogo(int x, int y) {
     int r = ringRadii[ring];
     // Draw arc from -50 to +50 degrees
     for (int angle = -55; angle <= 55; angle += 2) {
-      float rad = angle * 3.14159 / 180.0;
+      float rad = angle * PI / 180.0;
       int px = cx + (int)(r * sin(rad));
       int py = cy - (int)(r * cos(rad));
       display.drawPixel(px, py, SSD1306_WHITE);


### PR DESCRIPTION
- Added some more fingerprints for Flock devices from other projects on github. 
- Preparing some (hopefully) better support for other esp32-c5's like the XIAO (8mb flash, 8mb psram).
- Recovery logic code fixes for repeated wifi scans (currently not super steady), should clear and restart radio state every 5 min now (BLE wifi 2.4/5ghz all share the same onboard "radio"). 

